### PR TITLE
Fix for Flaggable as an STI model 

### DIFF
--- a/lib/make_flaggable/flagger.rb
+++ b/lib/make_flaggable/flagger.rb
@@ -76,8 +76,7 @@ module MakeFlaggable
 
     def fetch_flaggings(flaggable)
       flaggings.where({
-        :flaggable_type => flaggable.class.to_s,
-        :flaggable_id => flaggable.id
+        :flaggable => flaggable
       })
     end
 


### PR DESCRIPTION
Check flaggable using a where clause, so picks it picks the right table type of the flaggable in cases where flaggable uses STI.