### PR TITLE
Removed requirement for Rails 4.2

### DIFF
--- a/make_flaggable.gemspec
+++ b/make_flaggable.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.rubyforge_project         = "make_flaggable"
 
-  s.add_dependency "activerecord", ['>= 3.0', '< 4.2']
+  s.add_dependency "activerecord", '>= 3.0'
   s.add_development_dependency "bundler", ['>= 1.0.0', '<= 1.4']
   s.add_development_dependency "rspec", "~>2.14.0"
   s.add_development_dependency "database_cleaner", "1.0.1"


### PR DESCRIPTION
Rails is already at 4.2.1. This gem cannot be installed, but I can't see any reason to restrict it at the upper end.