### PR TITLE
Update for Rails 4.2.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,5 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in make_flaggable.gemspec
 gemspec
 
-gem "database_cleaner", "1.0.1"
 gem 'activerecord-jdbcsqlite3-adapter', :platforms => :jruby
 gem 'sqlite3', :platforms => :ruby

--- a/make_flaggable.gemspec
+++ b/make_flaggable.gemspec
@@ -14,8 +14,8 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.rubyforge_project         = "make_flaggable"
 
-  s.add_dependency "activerecord", ['>= 3.0', '< 4.2']
-  s.add_development_dependency "bundler", ['>= 1.0.0', '<= 1.4']
+  s.add_dependency "activerecord", ['>= 3.0', '~> 4.2.3']
+  s.add_development_dependency "bundler", '>= 1.0.0'
   s.add_development_dependency "rspec", "~>2.14.0"
   s.add_development_dependency "database_cleaner", "1.0.1"
   s.add_development_dependency "generator_spec", "~> 0.9.0"

--- a/make_flaggable.gemspec
+++ b/make_flaggable.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.rubyforge_project         = "make_flaggable"
 
-  s.add_dependency "activerecord", ['>= 3.0', '~> 4.2.3']
+  s.add_dependency "activerecord", '< 4.3'
   s.add_development_dependency "bundler", '>= 1.0.0'
   s.add_development_dependency "rspec", "~>2.14.0"
   s.add_development_dependency "database_cleaner", "1.0.1"

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -1,14 +1,17 @@
 ActiveRecord::Schema.define :version => 0 do
   create_table :flaggable_models, :force => true do |t|
     t.string :name
+    t.integer :flaggings_count
   end
 
   create_table :flagger_models, :force => true do |t|
     t.string :name
+    t.integer :flaggings_count
   end
 
   create_table :flagger_once_models, :force => true do |t|
     t.string :name
+    t.integer :flaggings_count
   end
 
   create_table :invalid_flaggable_models, :force => true do |t|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,9 +10,9 @@ require 'make_flaggable'
 
 ActiveRecord::Base.logger = Logger.new(File.dirname(__FILE__) + '/debug.log')
 ActiveRecord::Base.configurations = YAML::load_file(File.dirname(__FILE__) + '/database.yml')
-ActiveRecord::Base.establish_connection(ENV['DB'] || 'sqlite3')
+ActiveRecord::Base.establish_connection(ENV['DB'] || :sqlite3)
 
-ActiveRecord::Base.silence do
+ActiveRecord::Base.silence(:stdout) do
   ActiveRecord::Migration.verbose = false
 
   load(File.dirname(__FILE__) + '/schema.rb')


### PR DESCRIPTION
Allows newer versions of ActiveRecord.
Fixes `make_flaggable_spec` so that it will run, but does not fix `make_flaggable_generator_spec` since it requires a change in the `generator_spec` gem.